### PR TITLE
fix: cannot start plugin with name in `Resident` type

### DIFF
--- a/src/deepin-service-manager/pluginloader.cpp
+++ b/src/deepin-service-manager/pluginloader.cpp
@@ -110,8 +110,6 @@ void PluginLoader::loadByName(const QString &name)
             policy->deleteLater();
             continue;
         }
-        if (m_isResident != policy->isResident())
-            continue;
 
         ServiceBase *srv = createService(policy);
         if (srv == nullptr) {
@@ -178,8 +176,8 @@ QList<Policy *> PluginLoader::sortPolicy(QList<Policy *> policys)
             } else {
                 qCWarning(dsm_PluginLoader) << QString("service: %1 cannot found "
                                                        "dependency: %2!")
-                                                       .arg(policy->name)
-                                                       .arg(dependency);
+                                                   .arg(policy->name)
+                                                   .arg(dependency);
             }
         }
     }


### PR DESCRIPTION
让单个插件，不管是常驻还是非常驻，都可以单独启动，方便用户调试

Log: