### PR TITLE
fix:修复dde-appearance不能正常启动

### DIFF
--- a/misc/deepin-service-manager.service.in
+++ b/misc/deepin-service-manager.service.in
@@ -14,7 +14,7 @@ ReadOnlyPaths=/usr/lib/deepin-service-manager/
 DevicePolicy=closed
 
 ProtectSystem=full
-ProtectHome=yes
+#ProtectHome=yes
 PrivateTmp=yes
 PrivateDevices=yes
 PrivateNetwork=yes


### PR DESCRIPTION
service-manager的ProtectHome导致不能正常连接dbus

Task:https://pms.uniontech.com/task-view-365061.html