### PR TITLE
chore: 解决插件使用传递的dbus，处理dbus相关操作失败的问题

### DIFF
--- a/src/core/policy/policy.cpp
+++ b/src/core/policy/policy.cpp
@@ -15,6 +15,7 @@ Q_LOGGING_CATEGORY(dsm_policy, "[Policy]")
 
 Policy::Policy(QObject *parent)
     : QObject(parent)
+    , dbus(nullptr)
 {
 }
 

--- a/src/core/policy/policy.h
+++ b/src/core/policy/policy.h
@@ -5,6 +5,7 @@
 #ifndef POLICY_H
 #define POLICY_H
 
+#include <QDBusConnection>
 #include <QMap>
 #include <QObject>
 
@@ -140,6 +141,7 @@ public:
     SDKType sdkType;
     int startDelay;
     int idleTime;
+    QDBusConnection *dbus;
 };
 
 #endif // POLICY_H

--- a/src/core/service/serviceqtdbus.cpp
+++ b/src/core/service/serviceqtdbus.cpp
@@ -76,6 +76,10 @@ bool ServiceQtDBus::registerService()
 bool ServiceQtDBus::unregisterService()
 {
     qCInfo(dsm_service_qt) << "service unregister: " << policy->name;
+    if (policy->dbus) {
+        delete policy->dbus;
+        policy->dbus = nullptr;
+    }
 
     if (libFuncCall("DSMUnRegister", false)) {
         ServiceBase::unregisterService();
@@ -103,8 +107,8 @@ bool ServiceQtDBus::libFuncCall(const QString &funcName, bool isRegister)
         m_library->deleteLater();
         return false;
     }
-    auto connection = qDbusConnection();
-    int ret = objFunc(policy->name.toStdString().c_str(), (void *)&connection);
+    policy->dbus = new QDBusConnection( qDbusConnection());
+    int ret = objFunc(policy->name.toStdString().c_str(), (void *)policy->dbus);
     if (ret) {
         return false;
     }


### PR DESCRIPTION
之前传给插件的dbus是临时变量，需要存储