### PR TITLE
fix: rename deepin-service-plugins to dde-services

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Depends:
  ${shlibs:Depends},
  ${misc:Depends}
 Recommends:
- deepin-service-plugins
+ dde-services
 Description: deepin desktop-environment - service manager frame
  Load system plug-ins for unified management
 


### PR DESCRIPTION
deepin-service-plugins项目被重命名为dde-services，修改包名。
https://github.com/linuxdeepin/dde-services/commit/d785c211e958fa87e7cd3d98da77bc12a5a06ddf

Log: rename package