### PR TITLE
chore: update build dependencies dtkCore  in debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,8 @@ Build-Depends:  debhelper (>= 11),
  qt6-base-dev,
  qt6-tools-dev-tools,
  qt6-tools-dev,
- libsystemd-dev
+ libsystemd-dev,
+ libdtk6core-dev
 Standards-Version: 4.1.3
 Homepage: https://github.com/linuxdeepin
 


### PR DESCRIPTION
Added libdtk6core-dev to the build dependencies for improved functionality.

Log: as title