### PR TITLE
refactor: update Debian build hardening flags

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -3,6 +3,10 @@
 include /usr/share/dpkg/default.mk
 
 export QT_SELECT = qt6
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CFLAGS_MAINT_APPEND = -Wall
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack -Wl,-E
 
 PACK_VER = $(shell echo $(DEB_VERSION_UPSTREAM) | awk -F'[+_~-]' '{print $$1}')
 
@@ -10,4 +14,4 @@ PACK_VER = $(shell echo $(DEB_VERSION_UPSTREAM) | awk -F'[+_~-]' '{print $$1}')
 	dh $@ --parallel
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DVERSION=$(PACK_VER) -DCMAKE_CXX_FLAGS="-Wl,--as-needed"
+	dh_auto_configure -- -DVERSION=$(PACK_VER)


### PR DESCRIPTION
1. Added DEB_BUILD_MAINT_OPTIONS with hardening=+all for comprehensive security hardening
2. Included standard warning flags (-Wall) for C/C++ compilation
3. Enhanced linker flags with modern security features (RELRO, NOW, noexecstack)
4. Removed redundant --as-needed flag from dh_auto_configure as it's now in LDFLAGS
5. Added -Wl,-E to preserve exported symbols for better dynamic linking

These changes improve build security and follow Debian packaging best practices for hardening while maintaining compatibility.

refactor: 更新 Debian 构建加固标志

1. 添加 DEB_BUILD_MAINT_OPTIONS 并设置 hardening=+all 以实现全面的安全 加固
2. 为 C/C++ 编译包含标准警告标志 (-Wall)
3. 增强链接器标志，加入现代安全特性 (RELRO, NOW, noexecstack)
4. 从 dh_auto_configure 移除冗余的 --as-needed 标志，因为它现在在 LDFLAGS 中
5. 添加 -Wl,-E 以保留导出符号，实现更好的动态链接

这些更改提高了构建安全性，并遵循 Debian 打包的最佳实践，同时保持兼容性。