### PR TITLE
refactor: reduce log level from info to debug

### DIFF
--- a/src/core/service/qtdbushook.cpp
+++ b/src/core/service/qtdbushook.cpp
@@ -37,7 +37,7 @@ Q_LOGGING_CATEGORY(dsm_hook_qt, "[QDBusHook]")
 // if it is not a local message, hook exec at main thread
 void QTDBusSpyHook(const QDBusMessage &msg)
 {
-    qCInfo(dsm_hook_qt) << "--msg=" << msg;
+    qCDebug(dsm_hook_qt) << "--msg=" << msg;
 
     ServiceBase *serviceObj = nullptr;
     bool isSubPath;
@@ -49,12 +49,12 @@ void QTDBusSpyHook(const QDBusMessage &msg)
         return;
     }
     if (!serviceObj->isRegister()) {
-        qCInfo(dsm_hook_qt) << "--to register dbus object: " << msg.path();
+        qCDebug(dsm_hook_qt) << "--to register dbus object: " << msg.path();
         serviceObj->registerService();
     }
 
     if (!serviceObj->policy->isResident() && !serviceObj->isLockTimer()) {
-        qCInfo(dsm_hook_qt) << QString("--service: %1 will unregister in %2 minutes!")
+        qCDebug(dsm_hook_qt) << QString("--service: %1 will unregister in %2 minutes!")
                                    .arg(serviceObj->policy->name)
                                    .arg(serviceObj->policy->idleTime);
         QTimer::singleShot(0, serviceObj, SLOT(restartTimer()));
@@ -83,8 +83,8 @@ void QTDBusSpyHook(const QDBusMessage &msg)
 // if it is not a local message, hook exec at main thread
 int QTDBusHook(const QString &baseService, const QDBusMessage &msg)
 {
-    qCInfo(dsm_hook_qt) << "--baseService=" << baseService;
-    qCInfo(dsm_hook_qt) << "--msg=" << msg;
+    qCDebug(dsm_hook_qt) << "--baseService=" << baseService;
+    qCDebug(dsm_hook_qt) << "--msg=" << msg;
 
     ServiceBase *serviceObj = nullptr;
     bool isSubPath;
@@ -96,12 +96,12 @@ int QTDBusHook(const QString &baseService, const QDBusMessage &msg)
         return 0;
     }
     if (!serviceObj->isRegister()) {
-        qCInfo(dsm_hook_qt) << "--to register dbus object: " << msg.path();
+        qCDebug(dsm_hook_qt) << "--to register dbus object: " << msg.path();
         serviceObj->registerService();
     }
 
     if (!serviceObj->policy->isResident() && !serviceObj->isLockTimer()) {
-        qCInfo(dsm_hook_qt) << QString("--service: %1 will unregister in %2 minutes!")
+        qCDebug(dsm_hook_qt) << QString("--service: %1 will unregister in %2 minutes!")
                                    .arg(serviceObj->policy->name)
                                    .arg(serviceObj->policy->idleTime);
         QTimer::singleShot(0, serviceObj, SLOT(restartTimer()));

--- a/src/deepin-service-manager/CMakeLists.txt
+++ b/src/deepin-service-manager/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
 find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS Gui Core DBus)
+find_package(Dtk6 COMPONENTS Core)
 
 # Sources files
 file(GLOB_RECURSE SRCS
@@ -38,6 +39,7 @@ target_link_libraries(${BIN_NAME} PRIVATE
   Qt${QT_VERSION_MAJOR}::Gui
   Qt${QT_VERSION_MAJOR}::Core
   Qt${QT_VERSION_MAJOR}::DBus
+  Dtk6::Core
   core-service
 )
 

--- a/src/deepin-service-manager/main.cpp
+++ b/src/deepin-service-manager/main.cpp
@@ -12,6 +12,7 @@
 #include <QDebug>
 #include <QLoggingCategory>
 #include <QProcess>
+#include <DLog>
 
 #include <unistd.h>
 Q_LOGGING_CATEGORY(dsm_Main, "[Main]")
@@ -27,7 +28,9 @@ int main(int argc, char *argv[])
     } else {
         a = new QCoreApplication(argc, argv);
     }
-
+    
+    Dtk::Core::DLogManager::registerConsoleAppender();
+    Dtk::Core::DLogManager::registerJournalAppender();
     a->setApplicationVersion(VERSION);
 
     QCommandLineOption groupOption({ { "g", "group" }, "eg:core", "group name" });


### PR DESCRIPTION
Changed logging statements from qCInfo to qCDebug in policy checking and D-Bus hook functions to reduce log noise in production environments. Added DTK logging framework dependencies and initialization to enhance logging capabilities. The info-level logs were too verbose for normal operation but are still useful for debugging purposes.

The changes include:
1. Replace qCInfo with qCDebug in policy.cpp for permission checking logs
2. Replace qCInfo with qCDebug in qtdbushook.cpp for D-Bus message processing logs
3. Add DTK Core component dependency in CMakeLists.txt
4. Register console and journal appenders in main.cpp for DTK logging

refactor: 将日志级别从信息降为调试

将策略检查和D-Bus钩子函数中的日志语句从qCInfo改为qCDebug，以减少生产环境
中的日志噪音。添加DTK日志框架依赖和初始化以增强日志功能。信息级别的日志
在正常操作中过于冗长，但在调试时仍然有用。

更改包括：
1. 在policy.cpp中将权限检查日志从qCInfo改为qCDebug
2. 在qtdbushook.cpp中将D-Bus消息处理日志从qCInfo改为qCDebug
3. 在CMakeLists.txt中添加DTK Core组件依赖
4. 在main.cpp中注册控制台和日志应用器以支持DTK日志