### PR TITLE
[暂不合并]chore(service): add dde-thp-disable as ExecStartPre for all services

### DIFF
--- a/misc/deepin-service-group@.service.in
+++ b/misc/deepin-service-group@.service.in
@@ -6,6 +6,7 @@ StartLimitBurst=5
 StartLimitIntervalSec=60
 
 [Service]
+ExecStartPre=-/usr/libexec/dde-thp-disable
 ExecStart=/usr/bin/deepin-service-manager -g %i
 Restart=on-failure
 RestartSec=3

--- a/misc/deepin-service-manager.service.in
+++ b/misc/deepin-service-manager.service.in
@@ -9,6 +9,7 @@ StartLimitBurst=5
 StartLimitIntervalSec=60
 
 [Service]
+ExecStartPre=-/usr/libexec/dde-thp-disable
 ExecStart=/usr/bin/deepin-service-manager
 Restart=on-failure
 RestartSec=3

--- a/misc/deepin-service-plugin@.service.in
+++ b/misc/deepin-service-plugin@.service.in
@@ -3,6 +3,7 @@ Description=deepin-service-manager
 After=dbus.service @EXTRA_AFTER@
 
 [Service]
+ExecStartPre=-/usr/libexec/dde-thp-disable
 ExecStart=/usr/bin/deepin-service-manager -n %i
 @SYSTEMD_SLICE@
 


### PR DESCRIPTION
1. Added `ExecStartPre=-/usr/libexec/dde-thp-disable` to disable THP before service startup
2. Applied to deepin-service-manager, deepin-service-group@, and deepin-service-plugin@ services

Log: Add dde-thp-disable pre-start hook to all deepin service manager units

chore(service): 所有服务添加 dde-thp-disable 预启动命令

1. 在所有 service 文件中添加 `ExecStartPre=-/usr/libexec/dde-thp-disable`，启动前关闭透明大页
2. 同时作用于 deepin-service-manager、deepin-service-group@ 和 deepin-service-plugin@ 服务

Log: 为所有 deepin service manager 单元添加 dde-thp-disable 预启动钩子
PMS: TASK-390043