### PR TITLE
feat: add plugin load conditions

### DIFF
--- a/develop-guide.md
+++ b/develop-guide.md
@@ -91,6 +91,9 @@ F --> K
   "idleTime": 10,
   "dependencies": [],
   "startDelay": 0,
+  "condition": {
+    "sessionType": "wayland"
+  },
   "policy": [
     {
       "path": "/org/deepin/service/demo1"
@@ -111,6 +114,8 @@ F --> K
 - <font color=DodgerBlue>idleTime</font>: [可选]若服务是按需启动，则可以设置闲时时间，超时则会退出当前进程，单位为分钟
 - <font color=DodgerBlue>dependencies</font>: [可选]若依赖其他服务，可将服务名填在此处，在依赖启动之前不会启动此服务
 - <font color=DodgerBlue>startDelay</font>: [可选]若需要延时启动，可将延时时间填在此处，单位为秒
+- <font color=DodgerBlue>condition</font>: [可选]插件加载条件,运行环境不满足时跳过加载该插件,**不影响同组其他插件**。整个字段或其内任意子键缺省都视为不约束,保证老 JSON 行为不变。
+  - <font color=DodgerBlue>sessionType</font>: 期望的会话类型,例如 `"wayland"` / `"x11"`,通过比较 `XDG_SESSION_TYPE` 环境变量判定。**仅对用户级插件 (`user/`,SessionBus) 生效**;系统级插件 (`system/`,SystemBus) 下该子键被忽略并打 warning 日志,不影响加载。
 - <font color=DodgerBlue>policy</font>: [可选]配置路径隐藏等设置。对于按需启动的插件，需要配置 Path 用于服务发现。
 
 > 配置文件中必选字段为必须要填写字段，否则插件无法正常启动，可选字段可视情况选择填写即可！

--- a/src/core/policy/policy.cpp
+++ b/src/core/policy/policy.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -12,6 +12,22 @@
 #include <QLoggingCategory>
 
 Q_LOGGING_CATEGORY(dsm_policy, "[Policy]")
+
+// Detect current session type with fallback:
+static QString currentSessionType()
+{
+    const QString fromEnv = QString::fromLocal8Bit(qgetenv("XDG_SESSION_TYPE")).toLower();
+    if (!fromEnv.isEmpty()) {
+        return fromEnv;
+    }
+    if (!qgetenv("WAYLAND_DISPLAY").isEmpty()) {
+        return QStringLiteral("wayland");
+    }
+    if (!qgetenv("DISPLAY").isEmpty()) {
+        return QStringLiteral("x11");
+    }
+    return QString();
+}
 
 Policy::Policy(QObject *parent)
     : QObject(parent)
@@ -104,6 +120,47 @@ void Policy::parseConfig(const QString &path)
         qCWarning(dsm_policy) << "json error, parse policy error.";
         return;
     }
+
+    // Optional condition. Empty preserves old JSON behavior.
+    condition = ConditionSpec();
+    if (rootObj.contains("condition")) {
+        const QJsonValue &v = rootObj.value("condition");
+        if (v.isObject()) {
+            const QJsonObject &conditionObj = v.toObject();
+            jsonGetString(conditionObj, "sessionType", condition.sessionType);
+        } else {
+            qCWarning(dsm_policy) << "condition must be an object, ignored:" << name;
+        }
+    }
+}
+
+bool Policy::matchesEnvironment() const
+{
+    // No condition → always match (back-compat).
+    if (condition.isEmpty()) {
+        return true;
+    }
+
+    if (!condition.sessionType.isEmpty()) {
+        const QString actual = currentSessionType();
+        const QString expected = condition.sessionType.toLower();
+        if (actual.isEmpty()) {
+            // No session-type signal in env (typical on system bus, or misconfigured user env).
+            // Fail open (matches "missing condition = no constraint") and log loud.
+            qCCritical(dsm_policy) << "cannot determine current sessionType "
+                                      "(XDG_SESSION_TYPE / WAYLAND_DISPLAY / DISPLAY all empty); "
+                                      "allow plugin to load:" << name;
+            return true;
+        }
+        if (actual != expected) {
+            qCInfo(dsm_policy) << "skip plugin" << name
+                               << "expected sessionType:" << expected
+                               << "actual:" << actual;
+            return false;
+        }
+    }
+
+    return true;
 }
 
 bool Policy::readJsonFile(QJsonDocument &outDoc, const QString &fileName)

--- a/src/core/policy/policy.h
+++ b/src/core/policy/policy.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -23,6 +23,16 @@ struct PolicyPath
 
 typedef QMap<QString, PolicyPath> QMapPath;
 
+// Plugin load condition; empty = no constraint (back-compat with old JSON).
+struct ConditionSpec
+{
+    // Expected session type, e.g. "wayland" / "x11". Empty = no constraint.
+    // Honored only on SessionBus; on SystemBus the field is logged and ignored.
+    QString sessionType;
+
+    bool isEmpty() const { return sessionType.isEmpty(); }
+};
+
 class Policy : public QObject
 {
     Q_OBJECT
@@ -35,6 +45,10 @@ public:
     QStringList paths() const;
     bool allowSubPath(const QString &path) const;
     bool isResident() const;
+
+    // Whether the current environment satisfies this plugin's condition.
+    // Empty condition always returns true (back-compat).
+    bool matchesEnvironment() const;
 
     //    void Check(); // TODO
     void print();
@@ -77,6 +91,7 @@ public:
     int startDelay;
     int idleTime;
     QDBusConnection *dbus;
+    ConditionSpec condition;
 };
 
 #endif // POLICY_H

--- a/src/deepin-service-manager/pluginloader.cpp
+++ b/src/deepin-service-manager/pluginloader.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -74,6 +74,12 @@ void PluginLoader::loadByGroup(const QString &group)
             continue;
         }
 
+        if (!policy->matchesEnvironment()) {
+            qCInfo(dsm_PluginLoader) << "plugin condition not matched, skip:" << policy->name;
+            policy->deleteLater();
+            continue;
+        }
+
         if (policy->sdkType == SDKType::QT && !checkPluginQtVersion(policy->pluginPath)) {
             qCWarning(dsm_PluginLoader) << "plugin Qt version not match: " << USE_QT_VERSION_MAJOR;
             policy->deleteLater();
@@ -119,6 +125,12 @@ void PluginLoader::loadByName(const QString &name)
             continue;
         }
 
+        if (!policy->matchesEnvironment()) {
+            qCInfo(dsm_PluginLoader) << "plugin condition not matched, skip:" << policy->name;
+            policy->deleteLater();
+            continue;
+        }
+
         if (policy->sdkType == SDKType::QT && !checkPluginQtVersion(policy->pluginPath)) {
             qCWarning(dsm_PluginLoader) << "plugin Qt version not match: " << USE_QT_VERSION_MAJOR;
             policy->deleteLater();
@@ -151,6 +163,15 @@ QString PluginLoader::getGroup(const QString &name)
         Policy *policy = new Policy(this);
         policy->parseConfig(file.absoluteFilePath());
         if (policy->name == name) {
+            // Condition unmet → behave as if name not found, so PluginManager::loadByName
+            // short-circuits at the group.isEmpty() branch and skips RegisterGroup,
+            // avoiding an orphan GroupManager on the main process.
+            if (!policy->matchesEnvironment()) {
+                qCInfo(dsm_PluginLoader) << "condition not matched for" << name
+                                         << "treat as not found";
+                policy->deleteLater();
+                return QString();
+            }
             const QString &group = policy->group;
             policy->deleteLater();
             return group;

--- a/src/deepin-service-manager/servicemanager.cpp
+++ b/src/deepin-service-manager/servicemanager.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -69,17 +69,26 @@ void ServiceManager::initGroup(const QDBusConnection::BusType &type)
     const QString &configPath = QString("%1/%2/").arg(SERVICE_CONFIG_DIR).arg(typeMap[type]);
 
     QFileInfoList list = QDir(configPath).entryInfoList();
-    Policy *policy = new Policy(this);
+    // Fresh Policy per file. Reusing one instance leaks state across files
+    // when parseConfig early-returns and skips field resets.
     for (auto &&file : list) {
         if (!file.isFile() || (file.suffix().compare("json", Qt::CaseInsensitive) != 0)) {
             continue;
         }
+        Policy *policy = new Policy(this);
         policy->parseConfig(file.absoluteFilePath());
+        // Skip condition-mismatched policies before group collection, so a group
+        // with no matching plugin isn't spawned. A group is still kept as long
+        // as any of its policies matches.
+        if (!policy->matchesEnvironment()) {
+            policy->deleteLater();
+            continue;
+        }
         if (!groups.contains(policy->group) && !policy->group.isEmpty()) {
             groups.append(policy->group);
         }
+        policy->deleteLater();
     }
-    policy->deleteLater();
     // sort groups
     std::sort(groups.begin(),
               groups.end(),


### PR DESCRIPTION
Add optional plugin condition parsing so service JSON can restrict loading by session type.

Skip plugins whose environment condition does not match when loading by group or by name, and avoid spawning empty groups for condition-mismatched plugins.

Create a fresh Policy while collecting groups so parse failures cannot leak state between config files.

新增可选插件加载条件解析,服务 JSON 可以按会话类型限制加载。

在按组或按名称加载时跳过环境条件不匹配的插件,并避免为不匹配的插件启动空组。

收集组时为每个配置文件创建新的 Policy,避免解析失败后状态在配置之间串用。

Log: add plugin load conditions
Change-Id: I140019cc7bfe43c490467dd84b220af806e8d1b6