### PR TITLE
chore: update changelog to 1.0.22

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-service-manager (1.0.22) unstable; urgency=medium
+
+  * feat: add plugin load conditions
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 04 Jun 2026 19:33:01 +0800
+
 deepin-service-manager (1.0.21) unstable; urgency=medium
 
   * fix: correct systemd service dependencies and install location


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1.0.22

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1.0.22
- 目标分支: master

## Summary by Sourcery

Documentation:
- Document the 1.0.22 release details in debian/changelog.