### PR TITLE
fix(manager): detect service scope reliably

### DIFF
--- a/src/deepin-service-manager/main.cpp
+++ b/src/deepin-service-manager/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -14,9 +14,53 @@
 #include <QProcess>
 #include <DLog>
 
+#include <systemd/sd-login.h>
+
+#include <cstdlib>
 #include <unistd.h>
 #include <pwd.h>
 Q_LOGGING_CATEGORY(dsm_Main, "[Main]")
+
+static QString detectScopeBySystemd()
+{
+    /*
+     * 此函数仅在未指定 --scope 时调用，按进程所属的 systemd/logind
+     * 上下文自动判断服务级别：
+     *
+     * 1. 普通用户或 root 的 systemd --user 服务，以及用户直接登录后
+     *    从终端启动的进程，都属于对应用户的登录会话或 user manager。
+     *    sd_pid_get_owner_uid() 会返回该上下文的所有者 UID：
+     *      - owner UID 与进程真实 UID 相同：按 user 级服务处理；
+     *      - 普通用户通过 sudo/su 切换到 root 时，owner UID 通常仍是
+     *        原登录用户，而进程真实 UID 已变为 0：按 system 级处理。
+     *
+     * 2. 由 system manager 启动的 unit（例如 /etc/systemd/system/ 下
+     *    通过 systemctl start 启动的服务）不属于登录会话或 user
+     *    manager，sd_pid_get_owner_uid() 通常返回 -ENODATA；随后
+     *    sd_pid_get_unit() 会返回所属 system unit，因此按 system 级
+     *    处理。unit 中配置 User=root 或 User=deepin-daemon 不会改变
+     *    它仍是 system unit 这一事实。
+     *
+     * 3. 必须先判断 owner UID。user 服务同时嵌套在 system manager
+     *    的 user@<uid>.service 中，如果先调用 sd_pid_get_unit()，
+     *    可能把 systemd --user 服务误判成 system。
+     *
+     * 两个接口都无法判断时，在此按进程真实 UID 规则兜底。
+     */
+    const uid_t processUid = getuid();
+    uid_t ownerUid = 0;
+    if (sd_pid_get_owner_uid(0, &ownerUid) >= 0) {
+        return ownerUid == processUid ? QStringLiteral("user") : QStringLiteral("system");
+    }
+
+    char *unit = nullptr;
+    if (sd_pid_get_unit(0, &unit) >= 0) {
+        std::free(unit);
+        return QStringLiteral("system");
+    }
+
+    return processUid < 1000 ? QStringLiteral("system") : QStringLiteral("user");
+}
 
 int main(int argc, char *argv[])
 {
@@ -44,6 +88,7 @@ int main(int argc, char *argv[])
 
     QCommandLineOption groupOption({ { "g", "group" }, "eg:core", "group name" });
     QCommandLineOption nameOption({ { "n", "name" }, "eg:org.deepin.demo", "service name" });
+    QCommandLineOption scopeOption({ "s", "scope" }, "service scope: system or user", "scope");
     QCommandLineOption elfQtVerCheckOption("elf-qt-version-check", "service manager plugin so <path>", "path");
     QCommandLineParser parser;
     parser.setApplicationDescription("deepin service plugin loader");
@@ -51,6 +96,7 @@ int main(int argc, char *argv[])
     parser.addVersionOption();
     parser.addOption(groupOption);
     parser.addOption(nameOption);
+    parser.addOption(scopeOption);
     parser.addOption(elfQtVerCheckOption);
     parser.addHelpOption();
     parser.process(*a);
@@ -65,7 +111,19 @@ int main(int argc, char *argv[])
     const bool isSetGroup = parser.isSet(groupOption);
     const bool isSetName = parser.isSet(nameOption);
 
-    const QString &typeValue = getuid() < 1000 ? "system" : "user";
+    QString typeValue;
+    if (parser.isSet(scopeOption)) {
+        typeValue = parser.value(scopeOption).toLower();
+        if (typeValue != "system" && typeValue != "user") {
+            qCCritical(dsm_Main) << "invalid scope:" << typeValue
+                                 << "(expected system or user)";
+            return 2;
+        }
+    } else {
+        typeValue = detectScopeBySystemd();
+    }
+
+    qCDebug(dsm_Main) << "service scope:" << typeValue;
     const QString &groupValue = isSetGroup ? parser.value(groupOption) : QString();
     const QString &nameValue = isSetName ? parser.value(nameOption) : QString();
 


### PR DESCRIPTION
1. Add an optional scope argument for explicit system or user selection.
2. Detect login and user manager contexts through libsystemd.
3. Identify system units before falling back to UID classification.
4. Document root login, sudo, and system service behavior.

Log: Resolve service scope across system and user sessions.
Influence: Correct bus selection for root sessions.

fix(manager): 可靠识别服务作用域

1. 增加可选作用域参数，支持明确选择 system 或 user。
2. 通过 libsystemd 识别登录会话和用户管理器上下文。
3. 识别系统单元后再回退到 UID 分类逻辑。
4. 详细说明 root 登录、sudo 和系统服务的判断行为。

Log: 正确识别系统与用户会话中的服务作用域。
PMS: BUG-369105
PMS: BUG-369131
Influence: 修正 root 会话下的总线选择。